### PR TITLE
Enable "External Tomcat Configuration" feature for TomEE Buildpack

### DIFF
--- a/config/tomee.yml
+++ b/config/tomee.yml
@@ -19,6 +19,10 @@ tomee:
   version: 1.7.+
   repository_root: ! '{default.repository.root}/tomee'
   context_path:
+  external_configuration_enabled: false
+external_configuration:
+  version: 1.+
+  repository_root: ""
 lifecycle_support:
   version: 2.+
   repository_root: ! '{default.repository.root}/tomcat-lifecycle-support'

--- a/docs/container-tomee.md
+++ b/docs/container-tomee.md
@@ -7,7 +7,7 @@ The TomEE Container provides Java EE 6 Web Profile.  Applications are run as the
   </tr>
   <tr>
     <td><strong>Tags</strong></td>
-    <td><tt>tomee-instance=&lang;version&rang;</tt>, <tt>tomcat-lifecycle-support=&lang;version&rang;</tt>, <tt>tomcat-logging-support=&lang;version&rang;</tt>, <tt>tomcat-redis-store=&lang;version&rang;</tt> <i>(optional)</i>, <tt>tomee-resource-configuration=&lang;version&rang;</tt> <i>(optional)</i></td>
+    <td><tt>tomee-instance=&lang;version&rang;</tt>, <tt>tomcat-lifecycle-support=&lang;version&rang;</tt>, <tt>tomcat-logging-support=&lang;version&rang;</tt>, <tt>tomcat-redis-store=&lang;version&rang;</tt> <i>(optional)</i>, <tt>tomcat-external_configuration=&lang;version&rang;</tt> <i>(optional)</i>, <tt>tomee-resource-configuration=&lang;version&rang;</tt> <i>(optional)</i></td>
   </tr>
 </table>
 Tags are printed to standard output by the buildpack detect script
@@ -51,6 +51,9 @@ The container can be configured by modifying the [`config/tomee.yml`][] file in 
 | `tomee.context_path` | The context path to expose the application at.
 | `tomee.repository_root` | The URL of the TomEE repository index ([details][repositories]).
 | `tomee.version` | The version of TomEE to use. Candidate versions can be found in [this listing](http://download.pivotal.io.s3.amazonaws.com/tomee/index.yml).
+| `tomee.external_configuration_enabled` | Set to `true` to be able to supply an external TomEE configuration. Default is `false`.
+| `external_configuration.version` | The version of the External TomEE Configuration to use. Candidate versions can be found in the the repository that you have created to house the External TomEE Configuration. Note: It is required the external configuration to allow symlinks.
+| `external_configuration.repository_root` | The URL of the External TomEE Configuration repository index ([details][repositories]).
 
 ### Common configurations
 The version of TomEE can be configured by setting an environment variable.
@@ -67,7 +70,33 @@ $ cf set-env my-application JBP_CONFIG_TOMEE '{tomee: { context_path: /first-seg
 
 
 ### Additional Resources
-The container can also be configured by overlaying a set of resources on the default distribution.  To do this, add files to the `resources/tomee` directory in the buildpack fork.  For example, to override the default `logging.properties` add your custom file to `resources/tomee/conf/logging.properties`.
+The container can also be configured by overlaying a set of resources on the default distribution.  To do this follow one of the options below.
+
+#### Buildpack Fork
+Add files to the `resources/tomee` directory in the buildpack fork.  For example, to override the default `logging.properties` add your custom file to `resources/tomee/conf/logging.properties`.
+
+#### External TomEE Configuration
+Supply a repository with an external TomEE configuration.
+
+Example in a manifest.yml
+```
+env:
+  JBP_CONFIG_TOMEE: "{ tomee: { external_configuration_enabled: true }, external_configuration: { repository_root: \"http://repository...\" } }"
+```
+
+The artifacts that the repository provides must be in TAR format and must follow the TomEE archive structure:
+
+```
+tomee
+|__conf
+   |__context.xml
+   |__server.xml
+   |__web.xml
+   |...
+```
+
+Notes:
+* It is required the external configuration to allow symlinks. For more information check [Tomcat 7 configuration].
 
 ## Session Replication
 By default, the TomEE instance is configured to store all Sessions and their data in memory.  Under certain circumstances it my be appropriate to persist the Sessions and their data to a repository.  When this is the case (small amounts of data that should survive the failure of any individual instance), the buildpack can automatically configure TomEE to do so by binding an appropriate service.
@@ -116,4 +145,5 @@ This functionality can be found in the [`tomee-buildpack-resource-configuration`
 [`SPRING_PROFILES_ACTIVE`]: http://docs.spring.io/spring/docs/4.0.0.RELEASE/javadoc-api/org/springframework/core/env/AbstractEnvironment.html#ACTIVE_PROFILES_PROPERTY_NAME
 [Tomcat wiki]: http://wiki.apache.org/tomcat/HowTo/FasterStartUp
 [version syntax]: extending-repositories.md#version-syntax-and-ordering
+[Tomcat 7 configuration]: http://tomcat.apache.org/tomcat-7.0-doc/config/context.html#Standard_Implementation
 [`tomee-buildpack-resource-configuration`]: https://github.com/cloudfoundry-community/tomee-buildpack-resource-configuration

--- a/lib/java_buildpack/container/tomee.rb
+++ b/lib/java_buildpack/container/tomee.rb
@@ -19,6 +19,7 @@ require 'java_buildpack/container'
 require 'java_buildpack/container/tomcat/tomcat_insight_support'
 require 'java_buildpack/container/tomee/tomee_instance'
 require 'java_buildpack/container/tomee/tomee_resource_configuration'
+require 'java_buildpack/container/tomcat/tomcat_external_configuration'
 require 'java_buildpack/container/tomcat/tomcat_lifecycle_support'
 require 'java_buildpack/container/tomcat/tomcat_logging_support'
 require 'java_buildpack/container/tomcat/tomcat_access_logging_support'
@@ -50,7 +51,7 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::ModularComponent#sub_components)
       def sub_components(context)
-        [
+        components = [
           TomeeInstance.new(sub_configuration_context(context, 'tomee')),
           TomeeResourceConfiguration.new(sub_configuration_context(context, 'resource_configuration')),
           TomcatLifecycleSupport.new(sub_configuration_context(context, 'lifecycle_support')),
@@ -60,6 +61,12 @@ module JavaBuildpack
           TomcatGemfireStore.new(sub_configuration_context(context, 'gemfire_store')),
           TomcatInsightSupport.new(context)
         ]
+
+        tomee_configuration = @configuration['tomee']
+        components << TomcatExternalConfiguration.new(sub_configuration_context(context, 'external_configuration')) if
+          tomee_configuration['external_configuration_enabled']
+
+        components
       end
 
       # (see JavaBuildpack::Component::ModularComponent#supports?)

--- a/spec/java_buildpack/container/tomee_spec.rb
+++ b/spec/java_buildpack/container/tomee_spec.rb
@@ -35,10 +35,11 @@ describe JavaBuildpack::Container::Tomee do
       'lifecycle_support'      => lifecycle_support_configuration,
       'logging_support'        => logging_support_configuration,
       'access_logging_support' => access_logging_support_configuration,
-      'redis_store'            => redis_store_configuration }
+      'redis_store'            => redis_store_configuration,
+      'external_configuration' => tomcat_external_configuration }
   end
 
-  let(:tomee_configuration) { double('tomee-configuration') }
+  let(:tomee_configuration) { { 'external_configuration_enabled' => false } }
 
   let(:lifecycle_support_configuration) { double('lifecycle-support-configuration') }
 
@@ -47,6 +48,8 @@ describe JavaBuildpack::Container::Tomee do
   let(:access_logging_support_configuration) { double('logging-support-configuration') }
 
   let(:redis_store_configuration) { double('redis-store-configuration') }
+
+  let(:tomcat_external_configuration) { double('tomcat_external_configuration') }
 
   it 'detects WEB-INF',
      app_fixture: 'container_tomcat' do
@@ -86,6 +89,18 @@ describe JavaBuildpack::Container::Tomee do
     expect(component.command).to eq("test-var-2 test-var-1 #{java_home.as_env_var} JAVA_OPTS=\"test-opt-2 " \
                                       'test-opt-1 -Dhttp.port=$PORT" exec $PWD/.java-buildpack/tomee/bin/catalina.sh ' \
                                       'run')
+  end
+
+  context do
+
+    let(:tomee_configuration) { { 'external_configuration_enabled' => true } }
+
+    it 'creates submodule TomcatExternalConfiguration' do
+      expect(JavaBuildpack::Container::TomcatExternalConfiguration)
+        .to receive(:new).with(sub_configuration_context(tomcat_external_configuration))
+
+      component.sub_components context
+    end
   end
 
 end


### PR DESCRIPTION
Hi,

With this change I would like to enable in TomEE buildpack the extension point introduced in java buildpack. Thus it will be possible to supply an external configuration for TomEE.

Regards,
Violeta

