### PR TITLE
Generate correct configuration for TomEE 7.0.x

### DIFF
--- a/lib/java_buildpack/container/tomee/tomee_instance.rb
+++ b/lib/java_buildpack/container/tomee/tomee_instance.rb
@@ -23,6 +23,18 @@ module JavaBuildpack
 
     # Encapsulates the detect, compile, and release functionality for the TomEE instance.
     class TomeeInstance < TomcatInstance
+
+      protected
+
+      TOMEE_7 = JavaBuildpack::Util::TokenizedVersion.new('7.0.0').freeze
+
+      private_constant :TOMEE_7
+
+      # Checks whether TomEE instance is Tomcat 7 compatible
+      def tomcat_7_compatible
+        @version < TOMEE_7
+      end
+
     end
 
   end

--- a/spec/java_buildpack/container/tomee/tomee_instance_spec.rb
+++ b/spec/java_buildpack/container/tomee/tomee_instance_spec.rb
@@ -37,6 +37,20 @@ describe JavaBuildpack::Container::TomeeInstance do
       .to match(%r{<Listener className='org.apache.catalina.core.JasperListener'/>})
   end
 
+  context do
+    let(:version) { '7.0.1' }
+
+    it 'configures for TomEE 7.0.x',
+       app_fixture:   'container_tomcat',
+       cache_fixture: 'stub-tomcat.tar.gz' do
+
+      component.compile
+      expect((sandbox + 'conf/context.xml').read).to match(%r{<Context>[\s]*<Resources allowLinking='true'/>})
+      expect((sandbox + 'conf/server.xml').read)
+        .not_to match(%r{<Listener className='org.apache.catalina.core.JasperListener'/>})
+    end
+  end
+
   it 'extracts TomEE from a GZipped TAR',
      app_fixture:   'container_tomcat',
      cache_fixture: 'stub-tomcat.tar.gz' do


### PR DESCRIPTION
TomEE 7.0.x is based on Tomcat 8.5.x.
- allowLinking configuration is an attribute of the Resources element
- JasperListener is not needed anymore