### PR TITLE
GH-16: Support for deploying ear files via tomee buildpack

### DIFF
--- a/lib/java_buildpack/container/tomee.rb
+++ b/lib/java_buildpack/container/tomee.rb
@@ -68,10 +68,14 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::ModularComponent#supports?)
       def supports?
-        web_inf? && !JavaBuildpack::Util::JavaMainUtils.main_class(@application)
+        (web_inf? && !JavaBuildpack::Util::JavaMainUtils.main_class(@application)) || is_ear?
       end
 
       private
+
+      def is_ear?
+        (@application.root + 'META-INF/application.xml').exist?
+      end
 
       def web_inf?
         (@application.root + 'WEB-INF').exist?

--- a/spec/fixtures/container_ear_structure/META-INF/application.xml
+++ b/spec/fixtures/container_ear_structure/META-INF/application.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE application PUBLIC
+        "-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN"
+        "http://java.sun.com/dtd/application_1_3.dtd">
+<application>
+  <display-name>container_ear</display-name>
+  <module>
+    <ejb>sample.jar</ejb>
+  </module>
+  <module>
+    <web>
+      <web-uri>sample.war</web-uri>
+      <context-root>/sample</context-root>
+    </web>
+  </module>
+</application>

--- a/spec/java_buildpack/container/tomee_spec.rb
+++ b/spec/java_buildpack/container/tomee_spec.rb
@@ -68,6 +68,12 @@ describe JavaBuildpack::Container::Tomee do
     expect(component.supports?).not_to be
   end
 
+  it 'detects META-INF/application.xml',
+     app_fixture: 'container_ear_structure' do
+
+    expect(component.supports?).to be
+  end
+
   it 'creates submodules' do
     allow(JavaBuildpack::Container::TomeeInstance)
       .to receive(:new).with(sub_configuration_context(tomee_configuration))


### PR DESCRIPTION
tomee container matches the folder structure of the application, if it appears to be an exploded ear(by the presence of a application.xml in META-INF folder) it tries to support the deployment of the app - along with existing support of war and java main.