### PR TITLE
GH-16: Supports deploying EAR files

### DIFF
--- a/docs/container-tomee.md
+++ b/docs/container-tomee.md
@@ -1,9 +1,11 @@
 # TomEE Container
-The TomEE Container provides Java EE 6 Web Profile.  Applications are run as the root web application in a TomEE container.
+The TomEE Container provides Java EE 7 Web Profile.  Applications are run as the root web application in a TomEE container.
 
 <table>
   <tr>
-    <td><strong>Detection Criterion</strong></td><td>Existence of a <tt>WEB-INF/</tt> folder in the application directory and <a href="container-java_main.md">Java Main</a> not detected. If a META-INF/application.xml file is present then the application is considered an ear file and a deployment attempted. Note that TomEE supports only the JEE 7 [Web Profile](http://tomee.apache.org/comparison.html).
+    <td><strong>Detection Criterion</strong></td>
+    <td>Existence of a <tt>WEB-INF/</tt> folder in the application directory and <a href="container-java_main.md">Java Main</a> not detected. 
+    If a <tt>META-INF/application.xml</tt> file is present then the application is considered an ear file. Note that TomEE supports only the JEE 7 [Web Profile](http://tomee.apache.org/comparison.html).
     </td>
   </tr>
   <tr>
@@ -121,6 +123,29 @@ This configuration consists of:
 * properties provider - `org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider` that will supply the configuration properties for the corresponding cloud service.
 
 This functionality can be found in the [`tomee-buildpack-resource-configuration`][] Git repository.
+
+## Support for Deploying an ear(Enterprise Application aRchive) file
+TomEE buildpack supports the deployment of an [ear file](https://en.wikipedia.org/wiki/EAR_(file_format)) conforming to the Java EE 7 Web Profile. The expectation is that an ear file package a `META-INF/application.xml`, the deployment descriptor specifying all the modules packaged in the ear.
+Any external resources that the application requires can be specified in a [`META-INF/resources.xml`](http://tomee.apache.org/application-resources.html) file and is modified as described in [Resources Auto Configuration](#tomee-resources-auto-configuration) section.
+If the application requires any additional drivers for resources specified in the `META-INF/resources.xml` file then it can be packaged into a `drivers` folder and any file present here will be available for use by TomEE classloaders. 
+A sample structure of the ear with `META-INF/application.xml`, `drivers` and `META-INF/resources.xml` is the following:
+
+```
+sample.ear
+|____drivers
+| |____h2-1.4.193.jar
+|____eartest-ejb-impl-1.0.jar
+|____eartest-war1-1.0.war
+|____eartest-war2-1.0.war
+|____lib
+| |____eartest-ejb-api-1.0.jar
+|____META-INF
+| |____application.xml
+| |____resources.xml
+|____war-with-resource-1.0.war
+
+```
+
 
 [Configuration and Extension]: ../README.md#configuration-and-extension
 [`config/tomee.yml`]: ../config/tomee.yml

--- a/docs/container-tomee.md
+++ b/docs/container-tomee.md
@@ -3,7 +3,8 @@ The TomEE Container provides Java EE 6 Web Profile.  Applications are run as the
 
 <table>
   <tr>
-    <td><strong>Detection Criterion</strong></td><td>Existence of a <tt>WEB-INF/</tt> folder in the application directory and <a href="container-java_main.md">Java Main</a> not detected</td>
+    <td><strong>Detection Criterion</strong></td><td>Existence of a <tt>WEB-INF/</tt> folder in the application directory and <a href="container-java_main.md">Java Main</a> not detected. If a META-INF/application.xml file is present then the application is considered an ear file and a deployment attempted. Note that TomEE supports only the JEE 7 [Web Profile](http://tomee.apache.org/comparison.html).
+    </td>
   </tr>
   <tr>
     <td><strong>Tags</strong></td>

--- a/lib/java_buildpack/container/tomee.rb
+++ b/lib/java_buildpack/container/tomee.rb
@@ -68,12 +68,12 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::ModularComponent#supports?)
       def supports?
-        (web_inf? && !JavaBuildpack::Util::JavaMainUtils.main_class(@application)) || is_ear?
+        (web_inf? && !JavaBuildpack::Util::JavaMainUtils.main_class(@application)) || ear?
       end
 
       private
 
-      def is_ear?
+      def ear?
         (@application.root + 'META-INF/application.xml').exist?
       end
 

--- a/lib/java_buildpack/container/tomee.rb
+++ b/lib/java_buildpack/container/tomee.rb
@@ -68,10 +68,14 @@ module JavaBuildpack
 
       # (see JavaBuildpack::Component::ModularComponent#supports?)
       def supports?
-        web_inf? && !JavaBuildpack::Util::JavaMainUtils.main_class(@application)
+        (web_inf? && !JavaBuildpack::Util::JavaMainUtils.main_class(@application)) || is_ear?
       end
 
       private
+
+      def is_ear?
+        (@application.root + 'META-INF/application.xml').exist?
+      end
 
       def web_inf?
         (@application.root + 'WEB-INF').exist?

--- a/lib/java_buildpack/container/tomee/tomee_instance.rb
+++ b/lib/java_buildpack/container/tomee/tomee_instance.rb
@@ -30,13 +30,13 @@ module JavaBuildpack
         if ear?
           # if there is a drivers subfolder in the ear app, then link the libraries over to tomee/lib folder
           if drivers?
-            link_to((@application.root + 'drivers').children, web_inf_lib)
+            link_to((@application.root + 'drivers').children, lib_folder)
           end
         elsif tomcat_datasource_jar.exist?
           @droplet.additional_libraries << tomcat_datasource_jar
         end
 
-        @droplet.additional_libraries.link_to web_inf_lib
+        @droplet.additional_libraries.link_to lib_folder
       end
 
       protected
@@ -52,12 +52,11 @@ module JavaBuildpack
 
       private
 
-      def web_inf_lib
+      def lib_folder
         if ear?
-          # copy additional libraries to tomee lib folder
           tomcat_lib
         else
-          @droplet.root + 'WEB-INF/lib'
+          web_inf_lib
         end
       end
 

--- a/lib/java_buildpack/container/tomee/tomee_instance.rb
+++ b/lib/java_buildpack/container/tomee/tomee_instance.rb
@@ -27,9 +27,15 @@ module JavaBuildpack
       def compile
         download(@version, @uri) { |file| expand file }
         link_to(@application.root.children, root)
-        unless ear?
-          @droplet.additional_libraries << tomcat_datasource_jar if tomcat_datasource_jar.exist?
+        if ear?
+          # if there is a drivers subfolder in the ear app, then link the libraries over to tomee/lib folder
+          if drivers?
+            link_to((@application.root + 'drivers').children, web_inf_lib)
+          end
+        elsif tomcat_datasource_jar.exist?
+          @droplet.additional_libraries << tomcat_datasource_jar
         end
+
         @droplet.additional_libraries.link_to web_inf_lib
       end
 
@@ -57,6 +63,10 @@ module JavaBuildpack
 
       def ear?
         (@application.root + 'META-INF/application.xml').exist?
+      end
+
+      def drivers?
+        (@application.root + 'drivers/').exist?
       end
 
     end

--- a/lib/java_buildpack/container/tomee/tomee_resource_configuration.rb
+++ b/lib/java_buildpack/container/tomee/tomee_resource_configuration.rb
@@ -54,7 +54,7 @@ module JavaBuildpack
       end
 
       def mutate_resources_xml
-        with_timing 'Modifying /WEB-INF/resources.xml for Resource Configuration' do
+        with_timing "Modifying #{resources_xml} for Resource Configuration" do
           document = read_xml resources_xml
           @logger.debug { "  Original resources.xml: #{document}" }
 
@@ -87,11 +87,19 @@ module JavaBuildpack
       end
 
       def resources_xml
-        @droplet.root + 'WEB-INF/resources.xml'
+        if ear?
+          @droplet.root + 'META-INF/resources.xml'
+        else
+          @droplet.root + 'WEB-INF/resources.xml'
+        end
       end
 
       def read_xml(file)
         File.open(file, 'a+') { |f| REXML::Document.new f }
+      end
+
+      def ear?
+        (@application.root + 'META-INF/application.xml').exist?
       end
 
     end

--- a/spec/fixtures/container_ear_structure/META-INF/application.xml
+++ b/spec/fixtures/container_ear_structure/META-INF/application.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE application PUBLIC
+        "-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN"
+        "http://java.sun.com/dtd/application_1_3.dtd">
+<application>
+  <display-name>container_ear</display-name>
+  <module>
+    <ejb>sample.jar</ejb>
+  </module>
+  <module>
+    <web>
+      <web-uri>sample.war</web-uri>
+      <context-root>/sample</context-root>
+    </web>
+  </module>
+</application>

--- a/spec/fixtures/container_ear_structure_empty_resource/META-INF/application.xml
+++ b/spec/fixtures/container_ear_structure_empty_resource/META-INF/application.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE application PUBLIC
+        "-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN"
+        "http://java.sun.com/dtd/application_1_3.dtd">
+<application>
+  <display-name>container_ear</display-name>
+  <module>
+    <ejb>sample.jar</ejb>
+  </module>
+  <module>
+    <web>
+      <web-uri>sample.war</web-uri>
+      <context-root>/sample</context-root>
+    </web>
+  </module>
+</application>

--- a/spec/fixtures/container_ear_structure_empty_resource/META-INF/resources.xml
+++ b/spec/fixtures/container_ear_structure_empty_resource/META-INF/resources.xml
@@ -1,0 +1,2 @@
+<resources>
+</resources>

--- a/spec/fixtures/container_ear_structure_with_resource/META-INF/application.xml
+++ b/spec/fixtures/container_ear_structure_with_resource/META-INF/application.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE application PUBLIC
+        "-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN"
+        "http://java.sun.com/dtd/application_1_3.dtd">
+<application>
+  <display-name>container_ear</display-name>
+  <module>
+    <ejb>sample.jar</ejb>
+  </module>
+  <module>
+    <web>
+      <web-uri>sample.war</web-uri>
+      <context-root>/sample</context-root>
+    </web>
+  </module>
+</application>

--- a/spec/fixtures/container_ear_structure_with_resource/META-INF/resources.xml
+++ b/spec/fixtures/container_ear_structure_with_resource/META-INF/resources.xml
@@ -1,0 +1,3 @@
+<resources>
+  <Resource id="My Test Resource" type="my.test.Resource" provider="my.test#Provider"/>
+</resources>

--- a/spec/fixtures/container_ear_structure_with_resource_drivers/META-INF/application.xml
+++ b/spec/fixtures/container_ear_structure_with_resource_drivers/META-INF/application.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE application PUBLIC
+        "-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN"
+        "http://java.sun.com/dtd/application_1_3.dtd">
+<application>
+  <display-name>container_ear</display-name>
+  <module>
+    <ejb>sample.jar</ejb>
+  </module>
+  <module>
+    <web>
+      <web-uri>sample.war</web-uri>
+      <context-root>/sample</context-root>
+    </web>
+  </module>
+</application>

--- a/spec/fixtures/container_ear_structure_with_resource_drivers/META-INF/resources.xml
+++ b/spec/fixtures/container_ear_structure_with_resource_drivers/META-INF/resources.xml
@@ -1,0 +1,3 @@
+<resources>
+  <Resource id="My Test Resource" type="my.test.Resource" provider="my.test#Provider"/>
+</resources>

--- a/spec/java_buildpack/container/tomee/tomee_instance_spec.rb
+++ b/spec/java_buildpack/container/tomee/tomee_instance_spec.rb
@@ -153,4 +153,38 @@ describe JavaBuildpack::Container::TomeeInstance do
     expect(test_jar2.readlink).to eq((additional_libs_directory + 'test-jar-2.jar').relative_path_from(web_inf_lib))
   end
 
+  it 'links additional libraries to tomee/lib for an ear file',
+     app_fixture:   'container_ear_structure',
+     cache_fixture: 'stub-tomcat.tar.gz' do
+
+    component.compile
+
+    tomee_lib = sandbox + 'lib'
+
+    test_jar1 = sandbox + 'lib/test-jar-1.jar'
+    test_jar2 = sandbox + 'lib/test-jar-2.jar'
+    expect(test_jar1).to exist
+    expect(test_jar1).to be_symlink
+    expect(test_jar1.readlink).to eq((additional_libs_directory + 'test-jar-1.jar').relative_path_from(tomee_lib))
+
+    expect(test_jar2).to exist
+    expect(test_jar2).to be_symlink
+    expect(test_jar2.readlink).to eq((additional_libs_directory + 'test-jar-2.jar').relative_path_from(tomee_lib))
+  end
+
+  it 'links driver libraries to tomee/lib for an ear file',
+     app_fixture:   'container_ear_structure_with_resource_drivers',
+     cache_fixture: 'stub-tomcat.tar.gz' do
+
+    component.compile
+
+    tomee_lib = sandbox + 'lib'
+
+    test_jar1 = sandbox + 'lib/somedriver.txt'
+    expect(test_jar1).to exist
+    expect(test_jar1).to be_symlink
+    expect(test_jar1.readlink).to eq((app_dir + 'drivers/somedriver.txt').relative_path_from(tomee_lib))
+
+  end
+
 end

--- a/spec/java_buildpack/container/tomee_spec.rb
+++ b/spec/java_buildpack/container/tomee_spec.rb
@@ -68,6 +68,12 @@ describe JavaBuildpack::Container::Tomee do
     expect(component.supports?).not_to be
   end
 
+  it 'detects META-INF/application.xml',
+     app_fixture: 'container_ear_structure' do
+
+    expect(component.supports?).to be
+  end
+
   it 'creates submodules' do
     allow(JavaBuildpack::Container::TomeeInstance)
       .to receive(:new).with(sub_configuration_context(tomee_configuration))


### PR DESCRIPTION
This PR adds support to deploying ear files via tomee buildpack( #16  ), the changes are the following:

1. if the app package contains a META-INF/application.xml then it is considered an ear 
2. Additional libraries are placed in tomee/lib folder 
3. resources.xml is generated in META-INF/resources.xml file