### PR TITLE
Auto configuration to existing resource definitions

### DIFF
--- a/lib/java_buildpack/container/tomee/tomee_resource_configuration.rb
+++ b/lib/java_buildpack/container/tomee/tomee_resource_configuration.rb
@@ -76,11 +76,14 @@ module JavaBuildpack
       end
 
       def add_relational_resource(service, resources)
-        resources.add_element 'Resource',
-                              'id' => "jdbc/#{service['name']}",
-                              'type' => 'DataSource',
-                              'properties-provider' =>
-                              'org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'
+        resource = REXML::XPath.match(resources, "//*[@id = 'jdbc/#{service['name']}']").first
+        if resource.nil?
+          resource = resources.add_element 'Resource',
+                                           'id' => "jdbc/#{service['name']}",
+                                           'type' => 'DataSource'
+        end
+        resource.add_attribute 'properties-provider',
+                               'org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'
       end
 
       def resources_xml

--- a/spec/fixtures/container_tomee_nonempty_resources_xml_existing_resource/WEB-INF/resources.xml
+++ b/spec/fixtures/container_tomee_nonempty_resources_xml_existing_resource/WEB-INF/resources.xml
@@ -1,0 +1,4 @@
+<resources>
+  <Resource id="My Test Resource" type="my.test.Resource" provider="my.test#Provider"/>
+  <Resource id="jdbc/test" type="javax.sql.DataSource"/>
+</resources>

--- a/spec/java_buildpack/container/tomee/tomee_resource_configuration_spec.rb
+++ b/spec/java_buildpack/container/tomee/tomee_resource_configuration_spec.rb
@@ -113,6 +113,22 @@ provider='my.test#Provider'/>})
       expect(resources_xml.read).to match(%r{<Resource id='jdbc/test' type='DataSource' \
 properties-provider='org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'/>})
     end
+
+    it 'updates Resource element in resources.xml when such element already exists',
+       cache_fixture: 'stub-resource-configuration.jar',
+       app_fixture: 'container_tomee_nonempty_resources_xml_existing_resource' do
+
+      web_inf = app_dir + 'WEB-INF'
+      resources_xml = web_inf + 'resources.xml'
+      expect(resources_xml).to exist
+
+      component.compile
+
+      expect(resources_xml.read).to match(%r{<Resource id='My Test Resource' type='my.test.Resource' \
+provider='my.test#Provider'/>})
+      expect(resources_xml.read).to match(%r{<Resource id='jdbc/test' type='javax.sql.DataSource' \
+properties-provider='org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'/>})
+    end
   end
 
 end


### PR DESCRIPTION
o.c.r.tomee.DelegatingPropertiesProvider is added even when resource definition
exists in resources.xml so that the connection pool can be properly configured.