### PR TITLE
Add tomee jndi resource based on jdbcUrl in addition to relational tag

### DIFF
--- a/lib/java_buildpack/container/tomee/tomee_resource_configuration.rb
+++ b/lib/java_buildpack/container/tomee/tomee_resource_configuration.rb
@@ -70,9 +70,15 @@ module JavaBuildpack
 
       def relational_services_as_resources(resources)
         @application.services.each do |service|
-          next unless service['tags'].include? 'relational'
-          add_relational_resource service, resources
+          if (service['tags'].include? 'relational') || well_known_jdbc_schema?(service['credentials'])
+            add_relational_resource service, resources
+          end
         end
+      end
+
+      def well_known_jdbc_schema?(creds)
+        creds.key?('jdbcUrl') &&
+          creds['jdbcUrl'].start_with?('jdbc:mysql', 'jdbc:postgresql', 'jdbc:oracle', 'jdbc:db2', 'jdbc:sqlserver')
       end
 
       def add_relational_resource(service, resources)

--- a/spec/java_buildpack/container/tomee/tomee_resource_configuration_spec.rb
+++ b/spec/java_buildpack/container/tomee/tomee_resource_configuration_spec.rb
@@ -181,4 +181,157 @@ provider='my.test#Provider'/>})
 properties-provider='org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'/>})
     end
   end
+
+  context do
+    let(:vcap_services) do
+      {
+        'test-service-relational-tag' => [{ 'name'        => 'test-service-relational-tag', 'label' => 'label-1',
+                                            'tags'        => %w[tag1 relational], 'plan' => 'test-plan',
+                                            'credentials' => { 'uri' => 'test-uri' } }]
+      }
+    end
+
+    it 'adds resource element for services tagged with relational',
+       cache_fixture: 'stub-resource-configuration.jar',
+       app_fixture:   'container_ear_structure_empty_resource' do
+      meta_inf      = app_dir + 'META-INF'
+      resources_xml = meta_inf + 'resources.xml'
+      expect(resources_xml).to exist
+
+      component.compile
+
+      expect(resources_xml.read).to match(%r{<Resource id='jdbc/test-service-relational-tag' type='DataSource' \
+properties-provider='org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'/>})
+    end
+  end
+
+  context do
+    let(:vcap_services) do
+      {
+        'test-service-mysql-schema' => [{ 'name'        => 'test-service-mysql-schema',
+                                          'tags'        => [],
+                                          'credentials' => {
+                                            'jdbcUrl': 'jdbc:mysql://auser:apass@hostname.com:3306/mydb'
+                                          } }]
+      }
+    end
+
+    it 'adds resource element for services with jdbcUrl starting with jdbc:mysql',
+       cache_fixture: 'stub-resource-configuration.jar',
+       app_fixture:   'container_ear_structure_empty_resource' do
+      meta_inf      = app_dir + 'META-INF'
+      resources_xml = meta_inf + 'resources.xml'
+      expect(resources_xml).to exist
+
+      component.compile
+
+      expect(resources_xml.read).to match(%r{<Resource id='jdbc/test-service-mysql-schema' type='DataSource' \
+properties-provider='org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'/>})
+    end
+
+  end
+
+  context do
+    let(:vcap_services) do
+      {
+        'test-service-postgresql-schema' => [{ 'name'        => 'test-service-postgresql-schema',
+                                               'tags'        => [],
+                                               'credentials' => {
+                                                 'jdbcUrl': 'jdbc:postgresql://auser:apass@hostname.com:1521/mydb'
+                                               } }]
+      }
+    end
+
+    it 'adds resource element for services with jdbcUrl starting with jdbc:postgresql',
+       cache_fixture: 'stub-resource-configuration.jar',
+       app_fixture:   'container_ear_structure_empty_resource' do
+      meta_inf      = app_dir + 'META-INF'
+      resources_xml = meta_inf + 'resources.xml'
+      expect(resources_xml).to exist
+
+      component.compile
+
+      expect(resources_xml.read).to match(%r{<Resource id='jdbc/test-service-postgresql-schema' \
+type='DataSource' properties-provider='org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'/>})
+    end
+
+  end
+
+  context do
+    let(:vcap_services) do
+      {
+        'test-service-oracle-schema' => [{ 'name'        => 'test-service-oracle-schema',
+                                           'tags'        => [],
+                                           'credentials' => {
+                                             'jdbcUrl': 'jdbc:oracle://auser:apass@hostname.com:432/mydb'
+                                           } }]
+      }
+    end
+
+    it 'adds resource element for services with jdbcUrl starting with jdbc:oracle',
+       cache_fixture: 'stub-resource-configuration.jar',
+       app_fixture:   'container_ear_structure_empty_resource' do
+      meta_inf      = app_dir + 'META-INF'
+      resources_xml = meta_inf + 'resources.xml'
+      expect(resources_xml).to exist
+
+      component.compile
+
+      expect(resources_xml.read).to match(%r{<Resource id='jdbc/test-service-oracle-schema' \
+type='DataSource' properties-provider='org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'/>})
+    end
+
+  end
+
+  context do
+    let(:vcap_services) do
+      {
+        'test-service-db2-schema' => [{ 'name'        => 'test-service-db2-schema',
+                                        'tags'        => [],
+                                        'credentials' => {
+                                          'jdbcUrl': 'jdbc:db2://auser:apass@hostname.com:543/mydb'
+                                        } }]
+      }
+    end
+
+    it 'adds resource element for services with jdbcUrl starting with jdbc:db2',
+       cache_fixture: 'stub-resource-configuration.jar',
+       app_fixture:   'container_ear_structure_empty_resource' do
+      meta_inf      = app_dir + 'META-INF'
+      resources_xml = meta_inf + 'resources.xml'
+      expect(resources_xml).to exist
+
+      component.compile
+
+      expect(resources_xml.read).to match(%r{<Resource id='jdbc/test-service-db2-schema' \
+type='DataSource' properties-provider='org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'/>})
+    end
+
+  end
+
+  context do
+    let(:vcap_services) do
+      {
+        'test-service-sqlserver-schema' => [{ 'name'        => 'test-service-sqlserver-schema',
+                                              'tags'        => [],
+                                              'credentials' => {
+                                                'jdbcUrl': 'jdbc:sqlserver://auser:apass@hostname.com:4407/mydb'
+                                              } }]
+      }
+    end
+
+    it 'adds resource element for services with jdbcUrl starting with jdbc:sqlserver',
+       cache_fixture: 'stub-resource-configuration.jar',
+       app_fixture:   'container_ear_structure_empty_resource' do
+      meta_inf      = app_dir + 'META-INF'
+      resources_xml = meta_inf + 'resources.xml'
+      expect(resources_xml).to exist
+
+      component.compile
+
+      expect(resources_xml.read).to match(%r{<Resource id='jdbc/test-service-sqlserver-schema' \
+type='DataSource' properties-provider='org.cloudfoundry.reconfiguration.tomee.DelegatingPropertiesProvider'/>})
+    end
+
+  end
 end


### PR DESCRIPTION
Fixes GH: #21 

Supports adding jndi resource based on jdbcUrl for well known databases that Spring-Cloud Connector understands - mysql, postgres, oracle, sqlserver, db2.
